### PR TITLE
Fix minor ACE interactions

### DIFF
--- a/addons/gsri_opex/Stringtable.xml
+++ b/addons/gsri_opex/Stringtable.xml
@@ -140,6 +140,10 @@
 			<Original>Diver outfit</Original>
 			<French>Tenue de nageur de combat</French>
 		</Key>
+		<Key ID="STR_GSRI_FREMM_gearAsEmpty">
+			<Original>Regular fatigues</Original>
+			<French>Tenue régulière</French>
+		</Key>
 		<Key ID="STR_GSRI_FREMM_medicalMain">
 			<Original>Medical skills</Original>
 			<French>Compétences médicales</French>

--- a/addons/gsri_opex/config.cpp
+++ b/addons/gsri_opex/config.cpp
@@ -99,6 +99,7 @@ class CfgFunctions {
 			class getMedic {};
 			class getGunner {};
 			class getDiver {};
+			class getEmpty {};
 		};
 	};
 };

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddArsenal.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddArsenal.sqf
@@ -21,6 +21,7 @@ _actionGunner = ["actionGunner",localize "STR_GSRI_FREMM_gearAsGunner","",{call 
 _actionGrenadier = ["actionGrenadier",localize "STR_GSRI_FREMM_gearAsGrenadier","",{call GSRI_fnc_getGrenadier},{true}] call ace_interact_menu_fnc_createAction;
 _actionMedical = ["actionMedic",localize "STR_GSRI_FREMM_gearAsMedic","",{call GSRI_fnc_getMedic},{true}] call ace_interact_menu_fnc_createAction;
 _actionDiver = ["actionDiver",localize "STR_GSRI_FREMM_gearAsDiver","",{call GSRI_fnc_getDiver},{true}] call ace_interact_menu_fnc_createAction;
+_actionEmpty = ["actionEmpty",localize "STR_GSRI_FREMM_gearAsEmpty","",{call GSRI_fnc_getEmpty},{true}] call ace_interact_menu_fnc_createAction;
 
 _actionNoMed = ["actionNoMed",localize "STR_GSRI_FREMM_medicalNoMed","",{player setVariable ["ace_medical_medicclass", 0]},{true}] call ace_interact_menu_fnc_createAction;
 _actionMedic = ["actionMedic",localize "STR_GSRI_FREMM_medicalMedic","",{player setVariable ["ace_medical_medicclass", 1]},{true}] call ace_interact_menu_fnc_createAction;
@@ -34,7 +35,7 @@ for [{_i = 0}, {_i < 9}, {_i = _i+1}] do {
 	[_handle, 0, ["actionLockerMain"], _actionPreslotMain] call ace_interact_menu_fnc_addActionToObject;
 	{
 		[_handle, 0, ["actionLockerMain","actionPreslotMain"], _x] call ace_interact_menu_fnc_addActionToObject;
-	} forEach [_actionRifleman,_actionGrenadier,_actionGunner,_actionMedical,_actionDiver];
+	} forEach [_actionRifleman,_actionGrenadier,_actionGunner,_actionMedical,_actionDiver,_actionEmpty];
 	[_handle, 0, ["actionLockerMain"], _actionArsenalMain] call ace_interact_menu_fnc_addActionToObject;
 	{
 		[_handle, 0, ["actionLockerMain","actionArsenalMain"], _x] call ace_interact_menu_fnc_addActionToObject;

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
@@ -13,7 +13,7 @@ _fuel attachTo [_ship, [9.63,40.13,10.15]];
 _fuel setDir 90;
 
 // Dummy objects for hangar and flight deck
-_types = ["B_Heli_Transport_01_F", "B_Heli_Attack_01_dynamicLoadout_F", "B_Heli_Light_01_dynamicLoadout_F", "B_Heli_Light_01_F", "B_T_UAV_03_dynamicLoadout_F","MELB_AH6M","MELB_MH6M"];
+_types = ["B_Heli_Transport_01_F", "B_Heli_Attack_01_dynamicLoadout_F", "B_Heli_Light_01_dynamicLoadout_F", "B_Heli_Light_01_F", "B_T_UAV_03_dynamicLoadout_F","MELB_AH6M","MELB_MH6M","UK3CB_BAF_Apache_AH1_DynamicLoadoutUnlimited"];
 {
 	_helipad = "Land_HelipadEmpty_F" createVehicleLocal [0,0,0];
 	_helipad enableSimulation false;

--- a/addons/gsri_opex/functions/preslots/fn_getEmpty.sqf
+++ b/addons/gsri_opex/functions/preslots/fn_getEmpty.sqf
@@ -8,3 +8,4 @@ removeHeadgear player;
 removeGoggles player;
 player forceAddUniform "VSM_G2_camo_MultiCam";
 player addHeadgear "GSRI_beret";
+player addWeapon "ItemMap"

--- a/addons/gsri_opex/functions/preslots/fn_getEmpty.sqf
+++ b/addons/gsri_opex/functions/preslots/fn_getEmpty.sqf
@@ -1,0 +1,10 @@
+removeAllWeapons player;
+removeAllItems player;
+removeAllAssignedItems player;
+removeUniform player;
+removeVest player;
+removeBackpack player;
+removeHeadgear player;
+removeGoggles player;
+player forceAddUniform "VSM_G2_camo_MultiCam";
+player addHeadgear "GSRI_beret";


### PR DESCRIPTION
Fix issues initialy attributed to @AkenoSyh. Once merged this PR will :
- Add an empty preslot to the red lockers, giving the player only the default GSRI fatigues and a GSRI beret.
- Add AH-64 Apache from 3CB mod to the spawnable helicopters list. However, as mentionned in the dedicated issue, this chopper is not properly configured to be used with Lesh' Tow Mod, with a high risk of uncontrolled explosion at stake.