### PR TITLE
Allow adding arsenal actions on other objects

### DIFF
--- a/addons/gsri_opex/config.cpp
+++ b/addons/gsri_opex/config.cpp
@@ -100,6 +100,7 @@ class CfgFunctions {
 			class getGunner {};
 			class getDiver {};
 			class getEmpty {};
+			class setAsLocker {};
 		};
 	};
 };

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddArsenal.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddArsenal.sqf
@@ -1,68 +1,18 @@
-// Add Virtual Arsenal to red lockers in preparation area
-// Also add Presloting actions on grey lockers
+// Add locker features to red lockers in preparation area
 // by [GSRI] Cheitan
 
 // No task serverside
 if(isDedicated) exitWith {};
 
 params["_ship"];
-private [
-	"_start",
-	"_actionLockerMain",
-	"_actionArsenalMain",
-	"_actionPreslotMain",
-	"_actionMedicalMain",
-	"_actionArsenalACE",
-	"_actionArsenalBI",
-	"_actionRifleman",
-	"_actionGunner",
-	"_actionGrenadier",
-	"_actionMedical",
-	"_actionDiver",
-	"_actionEmpty",
-	"_actionNoMed",
-	"_actionMedic",
-	"_actionDoctor"
-];
-
-_start = [-2.42944,15.6,8.7];
-_actionLockerMain = ["actionLockerMain",localize "STR_GSRI_FREMM_lockerMain","",{},{true}] call ace_interact_menu_fnc_createAction;
-_actionArsenalMain = ["actionArsenalMain",localize "STR_GSRI_FREMM_arsenalMain","",{},{true}] call ace_interact_menu_fnc_createAction;
-_actionPreslotMain = ["actionPreslotMain",localize "STR_GSRI_FREMM_preslotMain","",{},{true}] call ace_interact_menu_fnc_createAction;
-_actionMedicalMain = ["actionMedicalMain",localize "STR_GSRI_FREMM_medicalMain","",{},{true}] call ace_interact_menu_fnc_createAction;
-
-_actionArsenalACE = ["actionArsenalACE",localize "STR_GSRI_FREMM_openArsenalACE","",{params ["_target", "_player"];[_target,_player,true] call ace_arsenal_fnc_openBox},{true}] call ace_interact_menu_fnc_createAction;
-_actionArsenalBI = ["actionArsenalBI",localize "STR_GSRI_FREMM_openArsenalBI","",{["Open",true] spawn bis_fnc_arsenal},{true}] call ace_interact_menu_fnc_createAction;
-
-_actionRifleman = ["actionRifleman",localize "STR_GSRI_FREMM_gearAsRifleman","",{call GSRI_fnc_getSoldier},{true}] call ace_interact_menu_fnc_createAction;
-_actionGunner = ["actionGunner",localize "STR_GSRI_FREMM_gearAsGunner","",{call GSRI_fnc_getGunner},{true}] call ace_interact_menu_fnc_createAction;
-_actionGrenadier = ["actionGrenadier",localize "STR_GSRI_FREMM_gearAsGrenadier","",{call GSRI_fnc_getGrenadier},{true}] call ace_interact_menu_fnc_createAction;
-_actionMedical = ["actionMedic",localize "STR_GSRI_FREMM_gearAsMedic","",{call GSRI_fnc_getMedic},{true}] call ace_interact_menu_fnc_createAction;
-_actionDiver = ["actionDiver",localize "STR_GSRI_FREMM_gearAsDiver","",{call GSRI_fnc_getDiver},{true}] call ace_interact_menu_fnc_createAction;
-_actionEmpty = ["actionEmpty",localize "STR_GSRI_FREMM_gearAsEmpty","",{call GSRI_fnc_getEmpty},{true}] call ace_interact_menu_fnc_createAction;
-
-_actionNoMed = ["actionNoMed",localize "STR_GSRI_FREMM_medicalNoMed","",{player setVariable ["ace_medical_medicclass", 0]},{true}] call ace_interact_menu_fnc_createAction;
-_actionMedic = ["actionMedic",localize "STR_GSRI_FREMM_medicalMedic","",{player setVariable ["ace_medical_medicclass", 1]},{true}] call ace_interact_menu_fnc_createAction;
-_actionDoctor = ["actionDoctor",localize "STR_GSRI_FREMM_medicalDoctor","",{player setVariable ["ace_medical_medicclass", 2]},{true}] call ace_interact_menu_fnc_createAction;
+private _start = [-2.42944,15.6,8.7];
 
 private _i = 0;
 for [{_i = 0}, {_i < 9}, {_i = _i+1}] do {
 	private _handle = "Land_Battery_F" createVehicleLocal [0,0,0];
 	_handle enableSimulation false;
 	_handle attachTo [_ship, (_start vectorAdd [0,(0.61*_i),0])];
-	[_handle, 0, [], _actionLockerMain] call ace_interact_menu_fnc_addActionToObject;
-	[_handle, 0, ["actionLockerMain"], _actionPreslotMain] call ace_interact_menu_fnc_addActionToObject;
-	{
-		[_handle, 0, ["actionLockerMain","actionPreslotMain"], _x] call ace_interact_menu_fnc_addActionToObject;
-	} forEach [_actionRifleman,_actionGrenadier,_actionGunner,_actionMedical,_actionDiver,_actionEmpty];
-	[_handle, 0, ["actionLockerMain"], _actionArsenalMain] call ace_interact_menu_fnc_addActionToObject;
-	{
-		[_handle, 0, ["actionLockerMain","actionArsenalMain"], _x] call ace_interact_menu_fnc_addActionToObject;
-	} forEach [_actionArsenalBI,_actionArsenalACE];
-	[_handle, 0, ["actionLockerMain"], _actionMedicalMain] call ace_interact_menu_fnc_addActionToObject;
-	{
-		[_handle, 0, ["actionLockerMain","actionMedicalMain"], _x] call ace_interact_menu_fnc_addActionToObject;
-	} forEach [_actionNoMed,_actionMedic,_actionDoctor];
+	[_handle] call GSRI_fnc_setAsLocker;
 };
 
 // grey lockers

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddBoatBays.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddBoatBays.sqf
@@ -25,7 +25,7 @@ if(isServer) then {
 };
 
 // Boat bays might not already exists for the first few clients to connect
-waitUntil{ !isNil{_ship getVariable ["GSRI_FREMM_Portboard_bay", objNull] getVariable "GSRI_FREMM_associatedCom"}};
+waitUntil{ !isNull (_ship getVariable ["GSRI_FREMM_Portboard_bay", objNull] getVariable ["GSRI_FREMM_associatedCom", objNull]) };
 
 // ACE actions are created clientside to avoid unnecessary network load
 private _actionSpawnInBay = ["actionSpawnInBay",localize "STR_GSRI_FREMM_spawnInBay","",{},{true}] call ace_interact_menu_fnc_createAction;

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddBoatBays.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddBoatBays.sqf
@@ -25,6 +25,7 @@ if(isServer) then {
 };
 
 // Boat bays might not already exists for the first few clients to connect
+if(isDedicated) exitWith {};
 waitUntil{ !isNull (_ship getVariable ["GSRI_FREMM_Portboard_bay", objNull] getVariable ["GSRI_FREMM_associatedCom", objNull]) };
 
 // ACE actions are created clientside to avoid unnecessary network load

--- a/addons/gsri_opex/functions/preslots/fn_setAsLocker.sqf
+++ b/addons/gsri_opex/functions/preslots/fn_setAsLocker.sqf
@@ -20,6 +20,9 @@ private [
 	"_actionMedicalMain",
 	"_medicalActions"
 ];
+_arsenalActions = [];
+_preslotsActions = [];
+_medicalActions = [];
 
 _actionLockerMain = ["actionLockerMain",localize "STR_GSRI_FREMM_lockerMain","",{},{true}] call ace_interact_menu_fnc_createAction;
 

--- a/addons/gsri_opex/functions/preslots/fn_setAsLocker.sqf
+++ b/addons/gsri_opex/functions/preslots/fn_setAsLocker.sqf
@@ -1,0 +1,51 @@
+// Add Arsenal actions to given object (_locker)
+// BI and ACE arsenal, GSRI preslots, ACE medical skills
+// by [GSRI] Cheitan
+
+// No serverside task
+if(isDedicated) exitWith {};
+
+// Direct type of target object must be Object
+params[["_locker", objNull, [ objNull ]]];
+
+// If target object not defined, abort
+if(isNull _locker) exitWith {};
+
+private [
+	"_actionLockerMain",
+	"_actionArsenalMain",
+	"_arsenalActions",
+	"_actionPreslotMain",
+	"_preslotsActions",
+	"_actionMedicalMain",
+	"_medicalActions"
+];
+
+_actionLockerMain = ["actionLockerMain",localize "STR_GSRI_FREMM_lockerMain","",{},{true}] call ace_interact_menu_fnc_createAction;
+
+// Arsenal actions
+_actionArsenalMain = ["actionArsenalMain",localize "STR_GSRI_FREMM_arsenalMain","",{},{true}] call ace_interact_menu_fnc_createAction;
+_arsenalActions pushBack (["actionArsenalACE",localize "STR_GSRI_FREMM_openArsenalACE","",{params ["_target", "_player"];[_target,_player,true] call ace_arsenal_fnc_openBox},{true}] call ace_interact_menu_fnc_createAction);
+_arsenalActions pushBack (["actionArsenalBI",localize "STR_GSRI_FREMM_openArsenalBI","",{["Open",true] spawn bis_fnc_arsenal},{true}] call ace_interact_menu_fnc_createAction);
+
+// Preslot actions
+_actionPreslotMain = ["actionPreslotMain",localize "STR_GSRI_FREMM_preslotMain","",{},{true}] call ace_interact_menu_fnc_createAction;
+_preslotsActions pushBack (["actionRifleman",localize "STR_GSRI_FREMM_gearAsRifleman","",{call GSRI_fnc_getSoldier},{true}] call ace_interact_menu_fnc_createAction);
+_preslotsActions pushBack (["actionGunner",localize "STR_GSRI_FREMM_gearAsGunner","",{call GSRI_fnc_getGunner},{true}] call ace_interact_menu_fnc_createAction);
+_preslotsActions pushBack (["actionGrenadier",localize "STR_GSRI_FREMM_gearAsGrenadier","",{call GSRI_fnc_getGrenadier},{true}] call ace_interact_menu_fnc_createAction);
+_preslotsActions pushBack (["actionMedic",localize "STR_GSRI_FREMM_gearAsMedic","",{call GSRI_fnc_getMedic},{true}] call ace_interact_menu_fnc_createAction);
+_preslotsActions pushBack (["actionDiver",localize "STR_GSRI_FREMM_gearAsDiver","",{call GSRI_fnc_getDiver},{true}] call ace_interact_menu_fnc_createAction);
+_preslotsActions pushBack (["actionEmpty",localize "STR_GSRI_FREMM_gearAsEmpty","",{call GSRI_fnc_getEmpty},{true}] call ace_interact_menu_fnc_createAction);
+
+// Medical skills actions
+_actionMedicalMain = ["actionMedicalMain",localize "STR_GSRI_FREMM_medicalMain","",{},{true}] call ace_interact_menu_fnc_createAction;
+_medicalActions pushBack (["actionNoMed",localize "STR_GSRI_FREMM_medicalNoMed","",{player setVariable ["ace_medical_medicclass", 0]},{true}] call ace_interact_menu_fnc_createAction);
+_medicalActions pushBack (["actionMedic",localize "STR_GSRI_FREMM_medicalMedic","",{player setVariable ["ace_medical_medicclass", 1]},{true}] call ace_interact_menu_fnc_createAction);
+_medicalActions pushBack (["actionDoctor",localize "STR_GSRI_FREMM_medicalDoctor","",{player setVariable ["ace_medical_medicclass", 2]},{true}] call ace_interact_menu_fnc_createAction);
+
+// Adding tree
+[_locker, 0, [], _actionLockerMain] call ace_interact_menu_fnc_addActionToObject;
+{ [_locker, 0, ["actionLockerMain"], _x] call ace_interact_menu_fnc_addActionToObject } forEach [_actionArsenalMain,_actionPreslotMain,_actionMedicalMain];
+{ [_locker, 0, ["actionLockerMain", "actionArsenalMain"], _x] call ace_interact_menu_fnc_addActionToObject } forEach _arsenalActions;
+{ [_locker, 0, ["actionLockerMain", "actionPreslotMain"], _x] call ace_interact_menu_fnc_addActionToObject } forEach _preslotsActions;
+{ [_locker, 0, ["actionLockerMain", "actionMedicalMain"], _x] call ace_interact_menu_fnc_addActionToObject } forEach _medicalActions;


### PR DESCRIPTION
When merge, this PR will allow a mission editor to add arsenal actions on custom objects, crates, etc. by using `[_target] call GSRI_fnc_setAsLocker`.

This PR will also fix a couple of quiet bugs (courtesy of @ArwynFr)