### PR TITLE
Fix unused variables warnings

### DIFF
--- a/addons/gsri_opex/functions/bays/fn_bayReplace.sqf
+++ b/addons/gsri_opex/functions/bays/fn_bayReplace.sqf
@@ -1,3 +1,4 @@
+// params ["_target", "_player", "_params"];
 params ["_target", "", "_params"];
 private ["_type", "_bay", "_cargo"];
 _type = (_params select 0);

--- a/addons/gsri_opex/functions/bays/fn_bayReplace.sqf
+++ b/addons/gsri_opex/functions/bays/fn_bayReplace.sqf
@@ -1,4 +1,4 @@
-params ["_target", "_player", "_params"];
+params ["_target", "", "_params"];
 private ["_type", "_bay", "_cargo"];
 _type = (_params select 0);
 _bay = (_target getVariable "GSRI_FREMM_associatedBay");

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
@@ -48,13 +48,13 @@ _types = ["B_Heli_Transport_01_F", "B_Heli_Attack_01_dynamicLoadout_F", "B_Heli_
 
 // Hangar cleaning action
 private _modifier = {
-    params ["_target", "_player", "_args", "_actionData"];
+    params ["", "", "_args", "_actionData"];
 	_args params ["_hangar"];
 	private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
     _actionData set [1, format [localize "STR_GSRI_FREMM_heliRemove", [_heli] call GSRI_fnc_heliMinifyName]];
 };
 private _condition = {
-	params ["_target", "_player", "_args"];
+	params ["", "", "_args"];
 	_args params ["_hangar"];
 	!isNull ([_hangar] call GSRI_fnc_heliRetrieveCurrent)
 };
@@ -63,7 +63,7 @@ private _actionClear = ["actionClear","Supprimer","",GSRI_fnc_heliRemove,_condit
 
 // FRIES mounting action
 private _condition = {
-	params ["_target", "_player", "_args"];
+	params ["", "", "_args"];
 	_args params ["_hangar"];
 	private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
 	(isNumber (configFile >> "CfgVehicles" >> typeOf _heli >> "ace_fastroping_enabled") && isNull (_heli getVariable ["ace_fastroping_FRIES", objNull]));
@@ -88,13 +88,13 @@ if(_leshLoaded && isServer) then {
 	// Place helicopter on rear deck
 	// Will not be externalized
 	private _condition = {
-		params["_target", "_player", "_args"];
+		params["", "", "_args"];
 		_args params ["_ship"];
 		// Return true if there is a heli in hangar and if there is no heli on deck
 		!(isNull ([(_ship getVariable "GSRI_FREMM_hangar")] call GSRI_fnc_heliRetrieveCurrent)) and (isNull ([(_ship getVariable "GSRI_FREMM_deck")] call GSRI_fnc_heliRetrieveCurrent))
 	};
 	private _statement = {
-		params["_target", "_player", "_args"];
+		params["", "", "_args"];
 		_args params ["_ship"];
 		private _heli = [(_ship getVariable "GSRI_FREMM_hangar")] call GSRI_fnc_heliRetrieveCurrent;
 		["HeliMoved", [getText (configFile >> "CfgVehicles" >> typeOf _heli >> "displayName")]] call BIS_fnc_showNotification;
@@ -106,13 +106,13 @@ if(_leshLoaded && isServer) then {
 	// Place helicopter in hangar
 	// Will not be externalized
 	private _condition = {
-		params["_target", "_player", "_args"];
+		params["", "", "_args"];
 		_args params ["_ship"];
 		// Return true if there is no heli in hangar and if there is a heli on deck
 		(isNull ([(_ship getVariable "GSRI_FREMM_hangar")] call GSRI_fnc_heliRetrieveCurrent)) and !(isNull ([(_ship getVariable "GSRI_FREMM_deck")] call GSRI_fnc_heliRetrieveCurrent))
 	};
 	private _statement = {
-		params["_target", "_player", "_args"];
+		params["", "", "_args"];
 		_args params ["_ship"];
 		private _heli = [(_ship getVariable "GSRI_FREMM_deck")] call GSRI_fnc_heliRetrieveCurrent;
 		["HeliMoved", [getText (configFile >> "CfgVehicles" >> typeOf _heli >> "displayName")]] call BIS_fnc_showNotification;

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
@@ -29,6 +29,7 @@ _types = ["B_Heli_Transport_01_F", "B_Heli_Attack_01_dynamicLoadout_F", "B_Heli_
 	if(isClass (configFile >> "CfgVehicles" >> _x)) then {
 		private _display = [_x] call GSRI_fnc_heliMinifyName;
 		private _modifier = {
+			// params ["_target", "_player", "_args", "_actionData"];
 			params ["", "", "_args", "_actionData"];
 			_args params ["_hangar", "_newType"];
 			private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
@@ -36,6 +37,7 @@ _types = ["B_Heli_Transport_01_F", "B_Heli_Attack_01_dynamicLoadout_F", "B_Heli_
 			_actionData set [1, format [_displayName, [_heli] call GSRI_fnc_heliMinifyName, [_newType] call GSRI_fnc_heliMinifyName]];
 		};
 		private _condition = {
+			// params["_target", "_player", "_args"];
 			params["", "", "_args"];
 			_args params ["_hangar", "_newType"];
 			private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
@@ -48,12 +50,14 @@ _types = ["B_Heli_Transport_01_F", "B_Heli_Attack_01_dynamicLoadout_F", "B_Heli_
 
 // Hangar cleaning action
 private _modifier = {
+	// params ["_target", "_player", "_args", "_actionData"];
     params ["", "", "_args", "_actionData"];
 	_args params ["_hangar"];
 	private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
     _actionData set [1, format [localize "STR_GSRI_FREMM_heliRemove", [_heli] call GSRI_fnc_heliMinifyName]];
 };
 private _condition = {
+	// params ["_target", "_player", "_args"];
 	params ["", "", "_args"];
 	_args params ["_hangar"];
 	!isNull ([_hangar] call GSRI_fnc_heliRetrieveCurrent)
@@ -63,6 +67,7 @@ private _actionClear = ["actionClear","Supprimer","",GSRI_fnc_heliRemove,_condit
 
 // FRIES mounting action
 private _condition = {
+	// params ["_target", "_player", "_args"];
 	params ["", "", "_args"];
 	_args params ["_hangar"];
 	private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
@@ -88,12 +93,14 @@ if(_leshLoaded && isServer) then {
 	// Place helicopter on rear deck
 	// Will not be externalized
 	private _condition = {
+		// params["_target", "_player", "_args"];
 		params["", "", "_args"];
 		_args params ["_ship"];
 		// Return true if there is a heli in hangar and if there is no heli on deck
 		!(isNull ([(_ship getVariable "GSRI_FREMM_hangar")] call GSRI_fnc_heliRetrieveCurrent)) and (isNull ([(_ship getVariable "GSRI_FREMM_deck")] call GSRI_fnc_heliRetrieveCurrent))
 	};
 	private _statement = {
+		// params["_target", "_player", "_args"];
 		params["", "", "_args"];
 		_args params ["_ship"];
 		private _heli = [(_ship getVariable "GSRI_FREMM_hangar")] call GSRI_fnc_heliRetrieveCurrent;
@@ -106,12 +113,14 @@ if(_leshLoaded && isServer) then {
 	// Place helicopter in hangar
 	// Will not be externalized
 	private _condition = {
+		// params["_target", "_player", "_args"];
 		params["", "", "_args"];
 		_args params ["_ship"];
 		// Return true if there is no heli in hangar and if there is a heli on deck
 		(isNull ([(_ship getVariable "GSRI_FREMM_hangar")] call GSRI_fnc_heliRetrieveCurrent)) and !(isNull ([(_ship getVariable "GSRI_FREMM_deck")] call GSRI_fnc_heliRetrieveCurrent))
 	};
 	private _statement = {
+		// params["_target", "_player", "_args"];
 		params["", "", "_args"];
 		_args params ["_ship"];
 		private _heli = [(_ship getVariable "GSRI_FREMM_deck")] call GSRI_fnc_heliRetrieveCurrent;

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddHeli.sqf
@@ -29,14 +29,14 @@ _types = ["B_Heli_Transport_01_F", "B_Heli_Attack_01_dynamicLoadout_F", "B_Heli_
 	if(isClass (configFile >> "CfgVehicles" >> _x)) then {
 		private _display = [_x] call GSRI_fnc_heliMinifyName;
 		private _modifier = {
-			params ["_target", "_player", "_args", "_actionData"];
+			params ["", "", "_args", "_actionData"];
 			_args params ["_hangar", "_newType"];
 			private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
 			private _displayName = [localize "STR_GSRI_FREMM_heliReplace", localize "STR_GSRI_FREMM_heliGet"] select (isNull _heli);
 			_actionData set [1, format [_displayName, [_heli] call GSRI_fnc_heliMinifyName, [_newType] call GSRI_fnc_heliMinifyName]];
 		};
 		private _condition = {
-			params["_target", "_player", "_args"];
+			params["", "", "_args"];
 			_args params ["_hangar", "_newType"];
 			private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
 			(([_newType] call GSRI_fnc_heliMinifyName) != ([_heli] call GSRI_fnc_heliMinifyName))

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -34,7 +34,8 @@ addMissionEventHandler ["MapSingleClick", GSRI_fnc_subSelectPos];
 
 // Adding "abort selection" eventHandler
 addMissionEventHandler ["Map", {
-	params ["_opened", ""];
+	// params ["_opened", "_forced"];
+	params ["_opened"];
 	// Detect if map is closed but do not check if the event is linked to this module
 	if!(_opened) then {
 		player setVariable ["GSRI_FREMM_submarine_token", false];
@@ -70,6 +71,7 @@ if!(isDedicated) then {
 		// Select the handle opposite to the one the player is interacting with
 		private _targetName = ["toSub", "toShip"] select (_x == "toSub");
 		private _statement = {
+			// params["_target", "_player", "_params"];
 			params["", "_player", "_params"];
 			_params params["_ship","_targetName"];
 			_player setPosASL getPosASL (_ship getVariable (format["GSRI_FREMM_submarine_%1", _targetName]));

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -34,7 +34,7 @@ addMissionEventHandler ["MapSingleClick", GSRI_fnc_subSelectPos];
 
 // Adding "abort selection" eventHandler
 addMissionEventHandler ["Map", {
-	params ["_opened", "_forced"];
+	params ["_opened", ""];
 	// Detect if map is closed but do not check if the event is linked to this module
 	if!(_opened) then {
 		player setVariable ["GSRI_FREMM_submarine_token", false];
@@ -70,7 +70,7 @@ if!(isDedicated) then {
 		// Select the handle opposite to the one the player is interacting with
 		private _targetName = ["toSub", "toShip"] select (_x == "toSub");
 		private _statement = {
-			params["_target", "_player", "_params"];
+			params["", "_player", "_params"];
 			_params params["_ship","_targetName"];
 			_player setPosASL getPosASL (_ship getVariable (format["GSRI_FREMM_submarine_%1", _targetName]));
 		};

--- a/addons/gsri_opex/functions/heli/fn_heliEquipFRIES.sqf
+++ b/addons/gsri_opex/functions/heli/fn_heliEquipFRIES.sqf
@@ -1,3 +1,4 @@
+// params ["_target", "_player", "_args"];
 params ["", "", "_args"];
 _args params ["_hangar"];
 private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;

--- a/addons/gsri_opex/functions/heli/fn_heliEquipFRIES.sqf
+++ b/addons/gsri_opex/functions/heli/fn_heliEquipFRIES.sqf
@@ -1,4 +1,4 @@
-params ["_target", "_player", "_args"];
+params ["", "", "_args"];
 _args params ["_hangar"];
 private _heli = [_hangar] call GSRI_fnc_heliRetrieveCurrent;
 ["HeliFRIES", [getText (configFile >> "CfgVehicles" >> typeOf _heli >> "displayName")]] call BIS_fnc_showNotification;

--- a/addons/gsri_opex/functions/heli/fn_heliRemove.sqf
+++ b/addons/gsri_opex/functions/heli/fn_heliRemove.sqf
@@ -1,4 +1,4 @@
-params ["_target", "_player", "_args"];
+params ["", "", "_args"];
 _args params ["_hangar"];
 private _heli = ([_hangar] call GSRI_fnc_heliRetrieveCurrent);
 ["HeliDelete", [getText (configFile >> "CfgVehicles" >> typeOf _heli >> "displayName")]] call BIS_fnc_showNotification;

--- a/addons/gsri_opex/functions/heli/fn_heliSpawn.sqf
+++ b/addons/gsri_opex/functions/heli/fn_heliSpawn.sqf
@@ -1,3 +1,4 @@
+params["_target", "_player", "_args"];
 params["", "", "_args"];
 
 // Allow suspension

--- a/addons/gsri_opex/functions/heli/fn_heliSpawn.sqf
+++ b/addons/gsri_opex/functions/heli/fn_heliSpawn.sqf
@@ -1,4 +1,4 @@
-params["_target", "_player", "_args"];
+params["", "", "_args"];
 
 // Allow suspension
 _args spawn {

--- a/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
@@ -1,5 +1,6 @@
 // Mandatory to get suspension allowed
 _this spawn {
+	// params ["_units", "_pos", "_alt", "_shift"];
 	params ["", "_pos", "", "_shift"];
 	private ["_maxDepth","_sub","_ship"];
 

--- a/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
@@ -1,6 +1,6 @@
 // Mandatory to get suspension allowed
 _this spawn {
-	params ["_units", "_pos", "_alt", "_shift"];
+	params ["", "_pos", "", "_shift"];
 	private ["_maxDepth","_sub","_ship"];
 
 	// Map click may happen but not linked to this module


### PR DESCRIPTION
Remove all unused variables from Opex, linter should not display them anymore.