### PR TITLE
Feature sub no teleport

### DIFF
--- a/addons/gsri_opex/CfgNotifications.hpp
+++ b/addons/gsri_opex/CfgNotifications.hpp
@@ -1,7 +1,6 @@
 class CfgNotifications
 {
-	class SubmarineOk
-	{
+	class SubmarineOk {
 		title = "GSRI Insertion System";
 		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconDone_ca.paa";
 		iconText = "";
@@ -11,27 +10,13 @@ class CfgNotifications
 		priority = 0;
 		difficulty[] = {};
 	};
-	class SubmarineFail
-	{
-		title = "GSRI Insertion System";
+	class SubmarineFail : SubmarineOk {
 		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconFailed_ca.paa";
-		iconText = "";
 		description = "$STR_GSRI_FREMM_submarineFail";
-		color[] = {1,1,1,1};
-		duration = 5;
-		priority = 0;
-		difficulty[] = {};
 	};
-	class SubmarineInfo
-	{
-		title = "GSRI Insertion System";
+	class SubmarineInfo : SubmarineOk {
 		iconPicture = "\A3\ui_f\data\map\mapcontrol\quay_ca.paa";
-		iconText = "";
 		description = "$STR_GSRI_FREMM_submarineInfo";
-		color[] = {1,1,1,1};
-		duration = 5;
-		priority = 0;
-		difficulty[] = {};
 	};
 	class HeliInfo
 	{

--- a/addons/gsri_opex/CfgNotifications.hpp
+++ b/addons/gsri_opex/CfgNotifications.hpp
@@ -1,5 +1,4 @@
-class CfgNotifications
-{
+class CfgNotifications {
 	class SubmarineOk {
 		title = "GSRI Insertion System";
 		iconPicture = "\A3\ui_f\data\map\mapcontrol\taskIconDone_ca.paa";
@@ -18,8 +17,7 @@ class CfgNotifications
 		iconPicture = "\A3\ui_f\data\map\mapcontrol\quay_ca.paa";
 		description = "$STR_GSRI_FREMM_submarineInfo";
 	};
-	class HeliInfo
-	{
+	class HeliInfo {
 		title = "GSRI Insertion System";
 		iconPicture = "\A3\ui_f\data\map\vehicleicons\iconhelicopter_ca.paa";
 		iconText = "";
@@ -29,16 +27,13 @@ class CfgNotifications
 		priority = 0;
 		difficulty[] = {};
 	};
-	class HeliDelete : HeliInfo
-	{
+	class HeliDelete : HeliInfo {
 		description = "$STR_GSRI_FREMM_heliDelete";
 	};
-	class HeliMoved : HeliInfo
-	{
+	class HeliMoved : HeliInfo {
 		description = "$STR_GSRI_FREMM_heliMoved";
 	};
-	class HeliFRIES : HeliInfo
-	{
+	class HeliFRIES : HeliInfo {
 		description = "$STR_GSRI_FREMM_heliFRIES";
 	};
 };

--- a/addons/gsri_opex/Stringtable.xml
+++ b/addons/gsri_opex/Stringtable.xml
@@ -257,9 +257,21 @@
 			<Original>Left-click to fast-move the submarine, 30m+ depth is required.</Original>
 			<French>Clic-gauche pour déplacement rapide, profondeur de 30m+ requise.</French>
 		</Key>
+		<Key ID="STR_GSRI_FREMM_submarine_control">
+			<Original>Submarine controls</Original>
+			<French>Contrôles du sous-marin</French>
+		</Key>
 		<Key ID="STR_GSRI_FREMM_submarine_selectPos">
-			<Original>Fast-move for the submarine.</Original>
-			<French>Déplacement rapide du sous-marin</French>
+			<Original>Select fast-travel destination</Original>
+			<French>Choisir une destination pour le voyage rapide</French>
+		</Key>
+		<Key ID="STR_GSRI_FREMM_submarine_doStop">
+			<Original>Full stop</Original>
+			<French>Arrêt complet</French>
+		</Key>
+		<Key ID="STR_GSRI_FREMM_submarine_doMove">
+			<Original>Engine start</Original>
+			<French>Démarrage moteur</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarine_deployCRRC">
 			<Original>Deploy CRRC</Original>

--- a/addons/gsri_opex/Stringtable.xml
+++ b/addons/gsri_opex/Stringtable.xml
@@ -261,14 +261,6 @@
 			<Original>Select position for the submarine.</Original>
 			<French>Choisir une destination pour le sous-marin</French>
 		</Key>
-		<Key ID="STR_GSRI_FREMM_submarine_go_toSub">
-			<Original>Go to submarine</Original>
-			<French>Aller au sous-marin</French>
-		</Key>
-		<Key ID="STR_GSRI_FREMM_submarine_go_toShip">
-			<Original>Go to frigate</Original>
-			<French>Aller à la frégate</French>
-		</Key>
 		<Key ID="STR_GSRI_FREMM_submarine_deployCRRC">
 			<Original>Deploy CRRC</Original>
 			<French>Déployer CRRC</French>

--- a/addons/gsri_opex/Stringtable.xml
+++ b/addons/gsri_opex/Stringtable.xml
@@ -120,6 +120,9 @@
 		<Key ID="STR_GSRI_FREMM_hasParajump_tooltip">
 			<Original>Add a parajump feature allowing players to deploy basically anywhere.</Original>
 			<French>Ajoute une solution de saut en parachute permettant un déploiement n'importe où.</French>
+		<Key ID="STR_GSRI_FREMM_navalGroup">
+			<Original>Naval detachment %1</Original>
+			<French>Détachement naval %1</French>
 		</Key>
 	</Package>
 	

--- a/addons/gsri_opex/Stringtable.xml
+++ b/addons/gsri_opex/Stringtable.xml
@@ -253,12 +253,12 @@
 			<French>Le sous-marin s'est déplacé aux coordonnées indiquées.</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarineFail">
-			<Original>Submarine cannot go here, 30m+ depth is required.</Original>
-			<French>Le sous-marin ne peut pas se déplacer ici, profondeur de 30m+ requise.</French>
+			<Original>Submarine cannot go here, 30m depth or more is required.</Original>
+			<French>Le sous-marin ne peut pas se déplacer ici, profondeur de 30m ou plus requise.</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarineInfo">
-			<Original>Left-click to fast-move the submarine, 30m+ depth is required.</Original>
-			<French>Clic-gauche pour déplacement rapide, profondeur de 30m+ requise.</French>
+			<Original>Left-click to fast-move the submarine, 30m depth or more is required.</Original>
+			<French>Clic-gauche pour déplacement rapide, profondeur de 30m ou plus requise.</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarine_control">
 			<Original>Submarine controls</Original>

--- a/addons/gsri_opex/Stringtable.xml
+++ b/addons/gsri_opex/Stringtable.xml
@@ -246,20 +246,20 @@
 
 	<Package name="FREMM_submarine">
 		<Key ID="STR_GSRI_FREMM_submarineOk">
-			<Original>Submarine has moved to the designated location (%1).</Original>
-			<French>Le sous-marin s'est déplacé aux coordonnées indiquées (%1).</French>
+			<Original>Submarine has moved to the designated location.</Original>
+			<French>Le sous-marin s'est déplacé aux coordonnées indiquées.</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarineFail">
-			<Original>Submarine cannot go here.</Original>
-			<French>Le sous-marin ne peut pas se déplacer ici.</French>
+			<Original>Submarine cannot go here, 30m+ depth is required.</Original>
+			<French>Le sous-marin ne peut pas se déplacer ici, profondeur de 30m+ requise.</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarineInfo">
-			<Original>Left-click to move, shift+click to move in surface.</Original>
-			<French>Clic-gauche pour déplacer, maj+clic pour déplacer à la surface.</French>
+			<Original>Left-click to fast-move the submarine, 30m+ depth is required.</Original>
+			<French>Clic-gauche pour déplacement rapide, profondeur de 30m+ requise.</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarine_selectPos">
-			<Original>Select position for the submarine.</Original>
-			<French>Choisir une destination pour le sous-marin</French>
+			<Original>Fast-move for the submarine.</Original>
+			<French>Déplacement rapide du sous-marin</French>
 		</Key>
 		<Key ID="STR_GSRI_FREMM_submarine_deployCRRC">
 			<Original>Deploy CRRC</Original>

--- a/addons/gsri_opex/config.cpp
+++ b/addons/gsri_opex/config.cpp
@@ -150,6 +150,7 @@ class CfgFunctions {
 			class parajumpRemoveWaiting {};
 		class sub {
 			file="gsri_opex\functions\sub";
+			class subAddControls {};
 			class subAddInterior {};
 			class subDeployCRRC {};
 			class subRetrieveCRRC {};

--- a/addons/gsri_opex/config.cpp
+++ b/addons/gsri_opex/config.cpp
@@ -148,6 +148,12 @@ class CfgFunctions {
 			class parajumpInit {};
 			class parajumpLaunchPlane {};
 			class parajumpRemoveWaiting {};
+		class sub {
+			file="gsri_opex\functions\sub";
+			class subAddInterior {};
+			class subDeployCRRC {};
+			class subRetrieveCRRC {};
+			class subSelectPos {};
 		};
 		class preslots {
 			file="gsri_opex\functions\preslots";

--- a/addons/gsri_opex/config.cpp
+++ b/addons/gsri_opex/config.cpp
@@ -148,13 +148,6 @@ class CfgFunctions {
 			class parajumpInit {};
 			class parajumpLaunchPlane {};
 			class parajumpRemoveWaiting {};
-		class sub {
-			file="gsri_opex\functions\sub";
-			class subAddControls {};
-			class subAddInterior {};
-			class subDeployCRRC {};
-			class subRetrieveCRRC {};
-			class subStop {};
 		};
 		class preslots {
 			file="gsri_opex\functions\preslots";
@@ -173,9 +166,12 @@ class CfgFunctions {
 		};
 		class sub {
 			file="gsri_opex\functions\sub";
+			class subAddControls {};
+			class subAddInterior {};
 			class subDeployCRRC {};
 			class subRetrieveCRRC {};
 			class subSelectPos {};
+			class subStop {};
 		};
 	};
 };

--- a/addons/gsri_opex/config.cpp
+++ b/addons/gsri_opex/config.cpp
@@ -153,7 +153,7 @@ class CfgFunctions {
 			class subAddInterior {};
 			class subDeployCRRC {};
 			class subRetrieveCRRC {};
-			class subSelectPos {};
+			class subStop {};
 		};
 		class preslots {
 			file="gsri_opex\functions\preslots";

--- a/addons/gsri_opex/functions/door/fn_doorConnect.sqf
+++ b/addons/gsri_opex/functions/door/fn_doorConnect.sqf
@@ -9,9 +9,10 @@ params["_corridor", ["_action", []]];
 if(count _action == 0) then {
 	// Composing default action
 	private _statement = {
-		params["_target", "_player"];
-		_player setPosWorld (_target getVariable "GSRI_FREMM_goTo");
-		private _goToShip = _target getVariable ["GSRI_FREMM_goToShip", false]; //When not define, assume that it's a door going from and to a custom room
+		params["_doorHandle", "_player"];
+		(_doorHandle getVariable "GSRI_FREMM_distantDoor") params ["_distantObject", "_distantRelPos"];
+		_player setPosWorld (_distantObject modelToWorldWorld _distantRelPos);
+		private _goToShip = _doorHandle getVariable ["GSRI_FREMM_goToShip", false]; //When not define, assume that it's a door going from and to a custom room
 		enableEnvironment _goToShip;
 	};
 	_action = ["actionCrossDoor",localize "STR_GSRI_FREMM_crewCrossDoor","",_statement,{true}] call ace_interact_menu_fnc_createAction;
@@ -22,13 +23,15 @@ private _doorB = [_objectB, _doorNameB] call GSRI_fnc_doorGetById;
 
 private _handle1 = (_doorA select 0) createVehicleLocal [0,0,0];
 _handle1 attachTo [_objectA, (_doorA select 2)];
-_handle1 setVariable ["GSRI_FREMM_goTo", _objectB modelToWorldWorld (_doorB select 3)];
+//_handle1 setVariable ["GSRI_FREMM_goTo", _objectB modelToWorldWorld (_doorB select 3)];
+_handle1 setVariable ["GSRI_FREMM_distantDoor", [_objectB, _doorB select 3]];
 if(count _doorA >= 4) then { _handle1 setDir (_doorA select 4) };
 if(count _doorA >= 5) then { _handle1 setVariable ["GSRI_FREMM_goToShip", _doorA select 5] };
 
 private _handle2 = (_doorB select 0) createVehicleLocal [0,0,0];
 _handle2 attachTo [_objectB, (_doorB select 2)];
-_handle2 setVariable ["GSRI_FREMM_goTo", _objectA modelToWorldWorld (_doorA select 3)];
+//_handle2 setVariable ["GSRI_FREMM_goTo", _objectA modelToWorldWorld (_doorA select 3)];
+_handle2 setVariable ["GSRI_FREMM_distantDoor", [_objectA, _doorA select 3]];
 if(count _doorB >= 4) then { _handle2 setDir (_doorB select 4) };
 if(count _doorB >= 5) then { _handle2 setVariable ["GSRI_FREMM_goToShip", _doorB select 5] };
 

--- a/addons/gsri_opex/functions/door/fn_doorConnect.sqf
+++ b/addons/gsri_opex/functions/door/fn_doorConnect.sqf
@@ -23,14 +23,12 @@ private _doorB = [_objectB, _doorNameB] call GSRI_fnc_doorGetById;
 
 private _handle1 = (_doorA select 0) createVehicleLocal [0,0,0];
 _handle1 attachTo [_objectA, (_doorA select 2)];
-//_handle1 setVariable ["GSRI_FREMM_goTo", _objectB modelToWorldWorld (_doorB select 3)];
 _handle1 setVariable ["GSRI_FREMM_distantDoor", [_objectB, _doorB select 3]];
 if(count _doorA >= 4) then { _handle1 setDir (_doorA select 4) };
 if(count _doorA >= 5) then { _handle1 setVariable ["GSRI_FREMM_goToShip", _doorA select 5] };
 
 private _handle2 = (_doorB select 0) createVehicleLocal [0,0,0];
 _handle2 attachTo [_objectB, (_doorB select 2)];
-//_handle2 setVariable ["GSRI_FREMM_goTo", _objectA modelToWorldWorld (_doorA select 3)];
 _handle2 setVariable ["GSRI_FREMM_distantDoor", [_objectA, _doorA select 3]];
 if(count _doorB >= 4) then { _handle2 setDir (_doorB select 4) };
 if(count _doorB >= 5) then { _handle2 setVariable ["GSRI_FREMM_goToShip", _doorB select 5] };

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -3,12 +3,15 @@ params["_ship"];
 // Submarine and teleport handles spawn
 if(isServer) then {
 	// Spawn and place sub
-	private _sub = "Submarine_01_F" createVehicle [0,0,0];
-	_sub enableSimulation false;
+	private _engine = createVehicle ["B_SDV_01_F", (getPosWorld _ship^vectorAdd [100,100,0])];
+	private _sub = "Submarine_01_F" createVehicle getPosWorld _sub;
 	_ship setVariable ["GSRI_FREMM_submarine", _sub, true];
-	_sub setPosASL [(getPosASL _ship select 0) + 100, (getPosASL _ship select 1) + 100, (getPosASL _ship select 2)-10];
-	_sub setDir getDir _ship;
+	_engine setDir getDir _ship;
+	_sub attachTo [_engine, [0,0,0]];
+	_sub setDir 180;
 	_sub setVariable ["GSRI_FREMM_shipIndex", _ship getVariable "GSRI_FREMM_shipIndex"];
+	_sub setVariable ["GSRI_FREMM_engine", _engine];
+	_engine setVariable ["GSRI_FREMM_sub", _sub];
 
 	// Add map marker
 	private _mk = createMarker [format["marker_submarine_%1", _sub getVariable "GSRI_FREMM_shipIndex"], _sub];

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -52,7 +52,7 @@ addMissionEventHandler ["Map", {
 	params ["_opened"];
 	// Detect if map is closed but do not check if the event is linked to this module
 	if!(_opened) then {
-		player setVariable ["GSRI_FREMM_submarine_token", false];
+		player setVariable ["GSRI_FREMM_engine", nil];
 		if!(player getVariable ["GSRI_FREMM_submarine_hadMap",true]) then { player unlinkItem "ItemMap"; player setVariable ["GSRI_FREMM_submarine_hadMap", nil] };
 	};
 }];
@@ -66,17 +66,13 @@ if!(isDedicated) then {
 
 	// Add actions with map selection
 	private _statement = {
+		params["_target", "_player", "_params"];
 		if!("ItemMap" in assignedItems player) then { player setVariable ["GSRI_FREMM_submarine_hadMap", false]; player linkItem "ItemMap" };
-		// Open the map
 		openMap true;
-
-		// Set the "submarine token" for the eventHandler to fire correctly
-		player setVariable ["GSRI_FREMM_submarine_token", true];
-
-		// Help notification
+		player setVariable ["GSRI_FREMM_engine", (_params select 0)];
 		["SubmarineInfo"] call BIS_fnc_showNotification;
 	};
-	private _actionSelectPos = ["submarineSelectPosition",localize "STR_GSRI_FREMM_submarine_selectPos","",_statement,{true}] call ace_interact_menu_fnc_createAction;
+	private _actionSelectPos = ["submarineSelectPosition",localize "STR_GSRI_FREMM_submarine_selectPos","",_statement,{true},{},[_ship getVariable "GSRI_FREMM_submarine" getVariable "GSRI_FREMM_engine"]] call ace_interact_menu_fnc_createAction;
 	[_com, 0, [], _actionSelectPos] call ace_interact_menu_fnc_addActionToObject;
 	
 	// Add CRRC deploy/retrieve actions

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -24,9 +24,13 @@ if(isServer) then {
 	_engine setVariable ["GSRI_FREMM_sub", _sub];
 
 	// Add map marker
-	private _mk = createMarker [format["marker_submarine_%1", _sub getVariable "GSRI_FREMM_shipIndex"], _sub];
-	_mk setMarkerType "flag_France";
-	_mk setMarkerText "S-625 Devigny";
+	[
+		west,
+		[format["taskSubmarine%1", _ship getVariable "GSRI_FREMM_shipIndex"], format["taskDestroyer%1_root", _ship getVariable "GSRI_FREMM_shipIndex"]],
+		["S-625 Devigny", "S-625 Devigny", ""],
+		[_engine, true],
+		"CREATED", -1, false, "boat"
+	] call BIS_fnc_taskCreate;
 
 	// CRRC handle and spawner
 	private _crrcSpawner = "Land_HelipadEmpty_F" createVehicle [0,0,0];

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -2,7 +2,7 @@ params["_ship"];
 
 // Submarine and teleport handles spawn
 if(isServer) then {
-	private ["_sub","_mk","_toSub","_toShip", "_crrcHandle", "_crrcSpawner"];
+	private ["_sub","_mk", "_crrcHandle", "_crrcSpawner"];
 	// Spawn and place sub
 	_sub = "Submarine_01_F" createVehicle [0,0,0];
 	_sub enableSimulation false;
@@ -15,18 +15,6 @@ if(isServer) then {
 	_mk = createMarker [format["marker_submarine_%1", _sub getVariable "GSRI_FREMM_shipIndex"], _sub];
 	_mk setMarkerType "flag_France";
 	_mk setMarkerText "S-625 Devigny";
-
-	// Create handle for TP to sub
-	_toSub = "Land_Battery_F" createVehicle [0,0,0];
-	_toSub enableSimulation false;
-	_toSub attachTo [_ship,[-2.21198,13.976,7.537]];
-	_ship setVariable ["GSRI_FREMM_submarine_toSub", _toSub, true];
-
-	// Handle for TP to ship
-	_toShip = "Land_Battery_F" createVehicle [0,0,0];
-	_toShip enableSimulation false;
-	_toShip attachTo [_ship getVariable "GSRI_FREMM_submarine", [0.0788574,-4.32037,3.1]];
-	_ship setVariable ["GSRI_FREMM_submarine_toShip", _toShip, true];
 
 	// CRRC handle and spawner
 	_crrcSpawner = "Land_HelipadEmpty_F" createVehicle [0,0,0];
@@ -78,20 +66,6 @@ if!(isDedicated) then {
 	};
 	private _actionSelectPos = ["submarineSelectPosition",localize "STR_GSRI_FREMM_submarine_selectPos","",_statement,{true}] call ace_interact_menu_fnc_createAction;
 	[_com, 0, [], _actionSelectPos] call ace_interact_menu_fnc_addActionToObject;
-
-	// Add teleport action
-	{
-		// Select the handle opposite to the one the player is interacting with
-		private _targetName = ["toSub", "toShip"] select (_x == "toSub");
-		private _statement = {
-			// params["_target", "_player", "_params"];
-			params["", "_player", "_params"];
-			_params params["_ship","_targetName"];
-			_player setPosASL getPosASL (_ship getVariable (format["GSRI_FREMM_submarine_%1", _targetName]));
-		};
-		private _actionGo = [format["action_%1",_x], localize format ["STR_GSRI_FREMM_submarine_go_%1", _x], "",_statement,{true},{},[_ship, _targetName]] call ace_interact_menu_fnc_createAction;
-		[(_ship getVariable format ["GSRI_FREMM_submarine_%1",_x]), 0, [], _actionGo] call ace_interact_menu_fnc_addActionToObject;
-	} forEach ["toSub", "toShip"];
 	
 	// Add CRRC deploy/retrieve actions
 	private _handle = (_ship getVariable "GSRI_FREMM_submarine") getVariable "GSRI_FREMM_sub_crrcHandle";

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -2,15 +2,23 @@ params["_ship"];
 
 // Submarine and teleport handles spawn
 if(isServer) then {
-	// Spawn and place sub
+	// Engine is the SDV which serve as a moving target object for the submarine
 	private _engine = createVehicle ["B_SDV_01_F", (getPosWorld _ship vectorAdd [100,100,0])];
 	createVehicleCrew _engine;
-	private _sub = "Submarine_01_F" createVehicle getPosWorld _engine;
-	_ship setVariable ["GSRI_FREMM_submarine", _sub, true];
 	_engine setDir (getDir _ship + 180);
-	_engine animateSource ["periscope", 1];
-	_sub attachTo [_engine, [0,0,-2]];
+	_engine allowDamage false;
+	driver _engine allowDamage false;
+	driver _engine disableAI "ALL";
+
+	// Sub is the submarine's skin and model, and also (for convenience) the attaching reference of action handles and stuff like that
+	private _sub = "Submarine_01_F" createVehicle getPosWorld _engine;
+	_sub attachTo [_engine, [0,-15,-3.5]];
+	_sub allowDamage false;
+	_sub enableSimulation false; //sub simul is always off, whereas engine simul varies following commander's choice to move the sub or make it still.
 	_sub setDir 180;
+
+	// A few needed variables for action functions
+	_ship setVariable ["GSRI_FREMM_submarine", _sub, true];
 	_sub setVariable ["GSRI_FREMM_shipIndex", _ship getVariable "GSRI_FREMM_shipIndex"];
 	_sub setVariable ["GSRI_FREMM_engine", _engine];
 	_engine setVariable ["GSRI_FREMM_sub", _sub];

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -60,24 +60,15 @@ addMissionEventHandler ["Map", {
 
 // Clientside jobs
 if!(isDedicated) then {
+	private _sub = _ship getVariable "GSRI_FREMM_submarine";
 	// Create handle for sub movement
 	private _com = "Land_Battery_F" createVehicleLocal [0,0,0];
 	_com enableSimulation false;
-	_com attachTo [_ship, [-2.94995,-34.0001,20.6]];
-
-	// Add actions with map selection
-	private _statement = {
-		params["_target", "_player", "_params"];
-		if!("ItemMap" in assignedItems player) then { player setVariable ["GSRI_FREMM_submarine_hadMap", false]; player linkItem "ItemMap" };
-		openMap true;
-		player setVariable ["GSRI_FREMM_engine", (_params select 0)];
-		["SubmarineInfo"] call BIS_fnc_showNotification;
-	};
-	private _actionSelectPos = ["submarineSelectPosition",localize "STR_GSRI_FREMM_submarine_selectPos","",_statement,{true},{},[_ship getVariable "GSRI_FREMM_submarine" getVariable "GSRI_FREMM_engine"]] call ace_interact_menu_fnc_createAction;
-	[_com, 0, [], _actionSelectPos] call ace_interact_menu_fnc_addActionToObject;
+	_com attachTo [_ship, [-2.94995,-34,20.6]];
+	[_sub, _com] call GSRI_fnc_subAddControls;
 	
 	// Add CRRC deploy/retrieve actions
-	private _handle = (_ship getVariable "GSRI_FREMM_submarine") getVariable "GSRI_FREMM_sub_crrcHandle";
+	private _handle = _sub getVariable "GSRI_FREMM_sub_crrcHandle";
 	private _crrcActions = [
 		["actionCRRC","CRRC",{},[]],
 		["actionCRRCSpawn",localize "STR_GSRI_FREMM_submarine_deployCRRC",GSRI_fnc_subDeployCRRC,["actionCRRC"]],

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -58,7 +58,10 @@ addMissionEventHandler ["Map", {
 	// Detect if map is closed but do not check if the event is linked to this module
 	if!(_opened) exitWith {};
 	player setVariable ["GSRI_FREMM_engine", nil];
-	if!(player getVariable ["GSRI_FREMM_submarine_hadMap",true]) then { player unlinkItem "ItemMap"; player setVariable ["GSRI_FREMM_submarine_hadMap", nil] };
+	if!(player getVariable ["GSRI_FREMM_submarine_hadMap",true]) then {
+		player unlinkItem "ItemMap";
+		player setVariable ["GSRI_FREMM_submarine_hadMap", nil]
+	};
 }];
 
 // Clientside jobs

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -2,9 +2,8 @@ params["_ship"];
 
 // Submarine and teleport handles spawn
 if(isServer) then {
-	private ["_sub","_mk", "_crrcHandle", "_crrcSpawner"];
 	// Spawn and place sub
-	_sub = "Submarine_01_F" createVehicle [0,0,0];
+	private _sub = "Submarine_01_F" createVehicle [0,0,0];
 	_sub enableSimulation false;
 	_ship setVariable ["GSRI_FREMM_submarine", _sub, true];
 	_sub setPosASL [(getPosASL _ship select 0) + 100, (getPosASL _ship select 1) + 100, (getPosASL _ship select 2)-10];
@@ -12,16 +11,16 @@ if(isServer) then {
 	_sub setVariable ["GSRI_FREMM_shipIndex", _ship getVariable "GSRI_FREMM_shipIndex"];
 
 	// Add map marker
-	_mk = createMarker [format["marker_submarine_%1", _sub getVariable "GSRI_FREMM_shipIndex"], _sub];
+	private _mk = createMarker [format["marker_submarine_%1", _sub getVariable "GSRI_FREMM_shipIndex"], _sub];
 	_mk setMarkerType "flag_France";
 	_mk setMarkerText "S-625 Devigny";
 
 	// CRRC handle and spawner
-	_crrcSpawner = "Land_HelipadEmpty_F" createVehicle [0,0,0];
+	private _crrcSpawner = "Land_HelipadEmpty_F" createVehicle [0,0,0];
 	_crrcSpawner attachTo [_sub, [0,17.4,5]];
 	_sub setVariable ["GSRI_FREMM_sub_crrcSpawner", _crrcSpawner, true];
 
-	_crrcHandle = "Land_Battery_F" createVehicle [0,0,0];
+	private _crrcHandle = "Land_Battery_F" createVehicle [0,0,0];
 	_crrcHandle attachTo [_sub, [0,12,3.74]];
 	_sub setVariable ["GSRI_FREMM_sub_crrcHandle", _crrcHandle, true];
 	_crrcHandle setVariable ["GSRI_FREMM_associatedSpawner", _crrcSpawner];

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -3,11 +3,13 @@ params["_ship"];
 // Submarine and teleport handles spawn
 if(isServer) then {
 	// Spawn and place sub
-	private _engine = createVehicle ["B_SDV_01_F", (getPosWorld _ship^vectorAdd [100,100,0])];
-	private _sub = "Submarine_01_F" createVehicle getPosWorld _sub;
+	private _engine = createVehicle ["B_SDV_01_F", (getPosWorld _ship vectorAdd [100,100,0])];
+	createVehicleCrew _engine;
+	private _sub = "Submarine_01_F" createVehicle getPosWorld _engine;
 	_ship setVariable ["GSRI_FREMM_submarine", _sub, true];
-	_engine setDir getDir _ship;
-	_sub attachTo [_engine, [0,0,0]];
+	_engine setDir (getDir _ship + 180);
+	_engine animateSource ["periscope", 1];
+	_sub attachTo [_engine, [0,0,-2]];
 	_sub setDir 180;
 	_sub setVariable ["GSRI_FREMM_shipIndex", _ship getVariable "GSRI_FREMM_shipIndex"];
 	_sub setVariable ["GSRI_FREMM_engine", _engine];

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -14,7 +14,7 @@ if(isServer) then {
 	private _sub = "Submarine_01_F" createVehicle getPosWorld _engine;
 	_sub attachTo [_engine, [0,-15,-3.5]];
 	_sub allowDamage false;
-	_sub enableSimulation false; //sub simul is always off, whereas engine simul varies following commander's choice to move the sub or make it still.
+	_sub enableSimulationGlobal false; //sub simul is always off, whereas engine simul varies following commander's choice to move the sub or make it still.
 	_sub setDir 180;
 
 	// A few needed variables for action functions

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -56,10 +56,9 @@ addMissionEventHandler ["Map", {
 	// params ["_opened", "_forced"];
 	params ["_opened"];
 	// Detect if map is closed but do not check if the event is linked to this module
-	if!(_opened) then {
-		player setVariable ["GSRI_FREMM_engine", nil];
-		if!(player getVariable ["GSRI_FREMM_submarine_hadMap",true]) then { player unlinkItem "ItemMap"; player setVariable ["GSRI_FREMM_submarine_hadMap", nil] };
-	};
+	if!(_opened) exitWith {};
+	player setVariable ["GSRI_FREMM_engine", nil];
+	if!(player getVariable ["GSRI_FREMM_submarine_hadMap",true]) then { player unlinkItem "ItemMap"; player setVariable ["GSRI_FREMM_submarine_hadMap", nil] };
 }];
 
 // Clientside jobs

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -37,6 +37,10 @@ if(isServer) then {
 	_crrcHandle attachTo [_sub, [0,12,3.74]];
 	_sub setVariable ["GSRI_FREMM_sub_crrcHandle", _crrcHandle, true];
 	_crrcHandle setVariable ["GSRI_FREMM_associatedSpawner", _crrcSpawner];
+
+	private _subDoors = [["Land_SewerCover_02_F", "Trapdoor", [0,-2.96,3.2], [0,-2.96,3.1]]];
+	_sub setVariable ["GSRI_FREMM_moddedDoors", _subDoors, true];
+	[_sub] call GSRI_fnc_subAddInterior;
 };
 
 // Adding position selection eventHandler

--- a/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_fremmAddSub.sqf
@@ -41,6 +41,7 @@ if(isServer) then {
 	private _subDoors = [["Land_SewerCover_02_F", "Trapdoor", [0,-2.96,3.2], [0,-2.96,3.1]]];
 	_sub setVariable ["GSRI_FREMM_moddedDoors", _subDoors, true];
 	[_sub] call GSRI_fnc_subAddInterior;
+	[_sub, true] call GSRI_fnc_subStop;
 };
 
 // Adding position selection eventHandler

--- a/addons/gsri_opex/functions/fremm/fn_initFremm.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_initFremm.sqf
@@ -43,9 +43,22 @@ if(isServer) then {
 	([_ship, 'Land_Destroyer_01_hull_05_F'] call bis_fnc_destroyer01GetShipPart) setObjectTextureGlobal [0, (_ship getVariable "GSRI_FREMM_nameplate")];
 
 	// Add map marker
-	private _mk = createMarker [format["marker_destroyer_%1", _ship getVariable "GSRI_FREMM_shipIndex"], _ship];
-	_mk setMarkerType "flag_France";
-	_mk setMarkerText (_ship getVariable "GSRI_FREMM_fullname");
+	private _fullname = _ship getVariable ["GSRI_FREMM_fullname", ""];
+	private _index = _ship getVariable "GSRI_FREMM_shipIndex";
+	[
+		west,
+		format["taskDestroyer%1_root", _index],
+		[format [localize "STR_GSRI_FREMM_navalGroup", _fullname], format [localize "STR_GSRI_FREMM_navalGroup", _fullname], ""],
+		objNull,
+		"CREATED", -1, false, "defend"
+	] call BIS_fnc_taskCreate;
+	[
+		west,
+		[format["taskDestroyer%1", _index], format["taskDestroyer%1_root", _index]],
+		[_fullname, _fullname, ""],
+		[_ship, true],
+		"CREATED", -1, false, "boat"
+	] call BIS_fnc_taskCreate;
 
 	// Signs array
 	private _signs = [
@@ -65,7 +78,7 @@ if(isServer) then {
 	} forEach _signs;
 
 	// Add Apex respawn position
-    [west, _ship modelToWorldWorld [1.31018,-1.11719,7.27226], _ship getVariable ["GSRI_FREMM_fullname",""]] call BIS_fnc_addRespawnPosition;
+    [west, _ship modelToWorldWorld [1.31018,-1.11719,7.27226], _fullname] call BIS_fnc_addRespawnPosition;
 };
 
 diag_log "initFremm finished.";

--- a/addons/gsri_opex/functions/fremm/fn_initFremm.sqf
+++ b/addons/gsri_opex/functions/fremm/fn_initFremm.sqf
@@ -45,19 +45,27 @@ if(isServer) then {
 	// Add map marker
 	private _fullname = _ship getVariable ["GSRI_FREMM_fullname", ""];
 	private _index = _ship getVariable "GSRI_FREMM_shipIndex";
+	private _navalGroupName = format [localize "STR_GSRI_FREMM_navalGroup", _fullname];
+	private _navalGroupTaskId = format["taskDestroyer%1_root", _index];
 	[
 		west,
-		format["taskDestroyer%1_root", _index],
-		[format [localize "STR_GSRI_FREMM_navalGroup", _fullname], format [localize "STR_GSRI_FREMM_navalGroup", _fullname], ""],
+		_navalGroupTaskId,
+		[_navalGroupName, _navalGroupName, ""],
 		objNull,
-		"CREATED", -1, false, "defend"
+		"CREATED",
+		-1,
+		false,
+		"defend"
 	] call BIS_fnc_taskCreate;
 	[
 		west,
-		[format["taskDestroyer%1", _index], format["taskDestroyer%1_root", _index]],
+		[format["taskDestroyer%1", _index], _navalGroupTaskId],
 		[_fullname, _fullname, ""],
 		[_ship, true],
-		"CREATED", -1, false, "boat"
+		"CREATED",
+		-1,
+		false,
+		"boat"
 	] call BIS_fnc_taskCreate;
 
 	// Signs array

--- a/addons/gsri_opex/functions/sub/fn_subAddControls.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subAddControls.sqf
@@ -1,0 +1,31 @@
+params["_sub", "_handle"];
+
+private _rootAction = ["submarineControl",localize "STR_GSRI_FREMM_submarine_control","",{},{true}] call ace_interact_menu_fnc_createAction;
+[_handle, 0, [], _rootAction] call ace_interact_menu_fnc_addActionToObject;
+
+// Sub's teleporter
+private _statement = {
+	params["_target", "_player", "_params"];
+	if!("ItemMap" in assignedItems player) then { player setVariable ["GSRI_FREMM_submarine_hadMap", false]; player linkItem "ItemMap" };
+	openMap true;
+	player setVariable ["GSRI_FREMM_engine", (_params select 0) getVariable "GSRI_FREMM_engine"];
+	["SubmarineInfo"] call BIS_fnc_showNotification;
+};
+private _condition = {
+	params["_target", "_player", "_params"];
+	!((_params select 0) getVariable ["GSRI_FREMM_subIsStill", false])
+};
+private _actionSelectPos = ["submarineSelectPosition",localize "STR_GSRI_FREMM_submarine_selectPos","",_statement,_condition,{},[_sub]] call ace_interact_menu_fnc_createAction;
+[_handle, 0, ["submarineControl"], _actionSelectPos] call ace_interact_menu_fnc_addActionToObject;
+
+// Make the sub still
+private _modifier = {
+	// params ["_target", "_player", "_args", "_actionData"];
+	params ["", "", "_args", "_actionData"];
+	_args params ["_sub"];
+	private _OnOff = _sub getVariable ["GSRI_FREMM_subIsStill", false];
+	_actionData set [1, localize format ["STR_GSRI_FREMM_submarine_%1",["doStop", "doMove"] select _OnOff]];
+	_actionData set [6, [_sub, !(_OnOff)]];
+};
+private _actionStop = ["submarineStop","","",{params["","","_args"]; _args call GSRI_fnc_subStop},{true},{},[_sub, false],"",2,[false, false, false, false, false], _modifier] call ace_interact_menu_fnc_createAction;
+[_handle, 0, ["submarineControl"], _actionStop] call ace_interact_menu_fnc_addActionToObject;

--- a/addons/gsri_opex/functions/sub/fn_subAddControls.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subAddControls.sqf
@@ -6,7 +6,10 @@ private _rootAction = ["submarineControl",localize "STR_GSRI_FREMM_submarine_con
 // Sub's teleporter
 private _statement = {
 	params["_target", "_player", "_params"];
-	if!("ItemMap" in assignedItems player) then { player setVariable ["GSRI_FREMM_submarine_hadMap", false]; player linkItem "ItemMap" };
+	if!("ItemMap" in assignedItems player) then {
+		player setVariable ["GSRI_FREMM_submarine_hadMap", false];
+		player linkItem "ItemMap";
+	};
 	openMap true;
 	player setVariable ["GSRI_FREMM_engine", (_params select 0) getVariable "GSRI_FREMM_engine"];
 	["SubmarineInfo"] call BIS_fnc_showNotification;

--- a/addons/gsri_opex/functions/sub/fn_subAddInterior.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subAddInterior.sqf
@@ -1,0 +1,74 @@
+params["_sub"];
+
+if(isServer) then {
+	private _shipIndex = _sub getVariable "GSRI_FREMM_shipIndex";
+	private _inside = createVehicle ["Land_Carrier_01_island_02_F", ASLToATL [25, (_shipIndex*100), 10]];
+	_inside setVectorUp [0,0,1];
+	_sub setVariable ["GSRI_FREMM_sub_interior", _inside, true];
+
+	private _props = [
+		["Land_PierLadder_F",[4.85046,-4.08545,-1.61897],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[5.01392,2.91797,0.0657654],[0,1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[5.01392,2.87744,0.387205],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[4.41675,2.87305,0.388365],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.43054,-3.22852,0.108538],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[5.01392,2.91846,0.713285],[0,1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[4.41675,2.91553,0.710718],[0,1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47205,-3.22803,-0.220612],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[5.0144,2.87646,-0.263384],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[5.01489,2.87646,-0.585655],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[4.41675,2.91504,0.0631981],[0,1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47766,-3.82422,-1.19231],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47327,-3.22705,-1.19347],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.43176,-3.22754,-0.864323],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.43469,-3.82471,-0.86689],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.48059,-4.42139,-1.19019],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[4.41724,2.87207,-0.262224],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47668,-3.82471,-0.541723],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47229,-3.22754,-0.542883],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47937,-4.42236,-0.217329],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47644,-3.8252,-0.219452],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47961,-4.42188,-0.539598],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[4.41772,2.87158,-0.584496],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.43347,-3.82568,0.10597],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[4.41772,2.91357,-0.909662],[0,1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47839,-4.42285,0.433262],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47546,-3.82568,0.431137],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.47107,-3.22852,0.429977],[1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.42993,-3.22852,0.756058],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.43286,-3.82568,0.75349],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.43677,-4.42383,0.751976],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[4.41821,2.87061,-1.23508],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[5.01538,2.87549,-1.23624],[0,-1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[5.01489,2.91699,-0.907095],[0,1,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.43738,-4.42383,0.104454],[-1,0,0],[0,0,1]],
+		["Land_PortableServer_01_black_F",[3.4386,-4.42285,-0.868406],[-1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09436,-2.37256,0.667238],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.0946,-2.88281,0.667969],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09436,-3.3916,0.667568],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09436,-2.88281,-0.948124],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09448,-2.37256,-0.948601],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09436,-3.39209,-0.948599],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09436,-3.39209,-0.140753],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09448,-2.37256,-0.140755],[1,0,0],[0,0,1]],
+		["Land_PortableCabinet_01_4drawers_black_F",[6.09436,-2.88281,-0.140278],[1,0,0],[0,0,1]],
+		["Land_SewerCover_02_F",[4.85742,-4.23633,0.934311],[0,-1,0],[0,-0,-1]],
+		["plp_cts_HighSecContGreyNoDollyO",[4.8634,-4.61865,3.86745],[0,0,-1],[0,1,0]]
+	];
+
+	{
+		private _prop = createVehicle [_x select 0, getPos _inside];
+		_prop attachTo [_inside, _x select 1];
+		_prop setVectorDirAndUp [_x select 2, _x select 3];
+	} forEach _props;
+
+	private _insideDoors = [
+		["Land_Battery_F", "Trapdoor", [4.85742,-4.23633,0.934311], [4.8999,-4.08594,-1.36511]]
+	];
+	_inside setVariable ["GSRI_FREMM_moddedDoors", _insideDoors, true];
+};
+
+if!(isDedicated) then {
+	private _corridors = [ [[_sub getVariable "GSRI_FREMM_sub_interior", "Trapdoor"],[_sub, "Trapdoor"]] ];
+	{ [_x] call GSRI_fnc_doorConnect } forEach _corridors;
+};

--- a/addons/gsri_opex/functions/sub/fn_subAddInterior.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subAddInterior.sqf
@@ -2,7 +2,7 @@ params["_sub"];
 
 if(isServer) then {
 	private _shipIndex = _sub getVariable "GSRI_FREMM_shipIndex";
-	private _inside = createVehicle ["Land_Carrier_01_island_02_F", ASLToATL [25, (_shipIndex*100), 10]];
+	private _inside = createVehicle ["Land_Carrier_01_island_02_F", ASLToATL [75, (_shipIndex*50), 10]];
 	_inside setVectorUp [0,0,1];
 	_sub setVariable ["GSRI_FREMM_sub_interior", _inside, true];
 

--- a/addons/gsri_opex/functions/sub/fn_subAddInterior.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subAddInterior.sqf
@@ -71,4 +71,9 @@ if(isServer) then {
 if!(isDedicated) then {
 	private _corridors = [ [[_sub getVariable "GSRI_FREMM_sub_interior", "Trapdoor"],[_sub, "Trapdoor"]] ];
 	{ [_x] call GSRI_fnc_doorConnect } forEach _corridors;
+
+	private _com = "Land_Tablet_02_black_F" createVehicle getPos _sub;
+	_com attachTo [_sub getVariable "GSRI_FREMM_sub_interior", [3.81714,-0.507,0.14]];
+	_com setVectorDirAndUp [[0,0,-1],[1,0,0]];
+	[_sub, _com] call GSRI_fnc_subAddControls;
 };

--- a/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
@@ -4,17 +4,18 @@ _this spawn {
 	params ["", "_pos"];
 
 	// Map click may happen but not linked to this module
-	if!(player getVariable ["GSRI_FREMM_submarine_token", false]) exitWith {};
+	if(isNull (player getVariable ["GSRI_FREMM_engine", objNull])) exitWith {};
 	
 	// Check if there is water here
 	private _availableDepth = abs (getTerrainHeightASL _pos);
 	if(_availableDepth > 30 and worldName != "VR") then {
 		private _engine = player getVariable "GSRI_FREMM_engine";
-		_pos set [2, "-20"];
+		_pos set [2, -20];
 		_engine setPosWorld _pos;
+		_engine swimInDepth -20;
 		["SubmarineOk"] call BIS_fnc_showNotification;
 		openMap false;
 	} else {
-		["SubmarineFail"] call BIS_fnc_showNotification};
+		["SubmarineFail"] call BIS_fnc_showNotification;
 	};
 };

--- a/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subSelectPos.sqf
@@ -1,35 +1,20 @@
 // Mandatory to get suspension allowed
 _this spawn {
 	// params ["_units", "_pos", "_alt", "_shift"];
-	params ["", "_pos", "", "_shift"];
-	private ["_maxDepth","_sub","_ship","_marker"];
+	params ["", "_pos"];
 
 	// Map click may happen but not linked to this module
 	if!(player getVariable ["GSRI_FREMM_submarine_token", false]) exitWith {};
 	
-	// Cannot pass custom arguments. Correct ship must be "guessed" based on location
-	_ship = nearestObject [player, "Land_Destroyer_01_base_F"];
-
 	// Check if there is water here
-	_maxDepth = getTerrainHeightASL _pos;
-	if(_maxDepth > -25 and worldName != "VR") exitWith { openMap false; ["SubmarineFail"] call BIS_fnc_showNotification};
-
-	// TODO : check if there is players around the sub, both at actual and targeted coordinates
-
-	// Select depth depending on Shift. key being pressed or not
-	_pos set [2,([-25, -10] select _shift)];
-
-	// Move submarine
-	_sub = (_ship getVariable "GSRI_FREMM_submarine");
-	_sub setPosASL _pos;
-	sleep 0.1;
-	_marker = format ["marker_submarine_%1", _sub getVariable "GSRI_FREMM_shipIndex"];
-	_marker setMarkerPos getPosASL _sub;
-	(_ship getVariable "GSRI_FREMM_submarine_toShip") attachTo [_sub, [0.0788574,-4.32037,3.1]];
-	(_sub getVariable "GSRI_FREMM_sub_crrcHandle") attachTo [_sub, [0,12,3.74]];
-	(_sub getVariable "GSRI_FREMM_sub_crrcSpawner") attachTo [_sub, [0,17.4,5]];
-	["SubmarineOk", [["submerged", "surfaced"] select _shift]] call BIS_fnc_showNotification;
-
-	// Finally, map must be closed, flag and map are removed by another eventHandler (see initSubmarine)
-	openMap false;
+	private _availableDepth = abs (getTerrainHeightASL _pos);
+	if(_availableDepth > 30 and worldName != "VR") then {
+		private _engine = player getVariable "GSRI_FREMM_engine";
+		_pos set [2, "-20"];
+		_engine setPosWorld _pos;
+		["SubmarineOk"] call BIS_fnc_showNotification;
+		openMap false;
+	} else {
+		["SubmarineFail"] call BIS_fnc_showNotification};
+	};
 };

--- a/addons/gsri_opex/functions/sub/fn_subStop.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subStop.sqf
@@ -3,7 +3,8 @@ params["_sub", "_stop"];
 private _engine = _sub getVariable "GSRI_FREMM_engine";
 
 _engine enableSimulationGlobal !(_stop);
+_engine engineOn !(_stop);
 
-if(_stop) then {detach _sub} else {_sub attachTo [_engine, [0,-15,-3.5]]};
+if(_stop) then {detach _sub} else {_sub attachTo [_engine, [0,-15,-3.5]]; _sub setDir 180};
 
 _sub setVariable ["GSRI_FREMM_subIsStill", _stop, true];

--- a/addons/gsri_opex/functions/sub/fn_subStop.sqf
+++ b/addons/gsri_opex/functions/sub/fn_subStop.sqf
@@ -1,0 +1,9 @@
+params["_sub", "_stop"];
+
+private _engine = _sub getVariable "GSRI_FREMM_engine";
+
+_engine enableSimulationGlobal !(_stop);
+
+if(_stop) then {detach _sub} else {_sub attachTo [_engine, [0,-15,-3.5]]};
+
+_sub setVariable ["GSRI_FREMM_subIsStill", _stop, true];


### PR DESCRIPTION
This PR will provide a more enjoyable submarine. It is now mobile, and can be driven by the use of Zeus remote-control (non-Zeus control will come later on). There is no more any way to teleport from the ship to the sub and back. Transfer between the two ships must be done by boat when the submarine is close by and stopped.

Making the submarine still by stopping the engine is not required for people to get in/out, but it allows to do so more safely : moving such an object requires cutting some angles regarding the physx handling, collision model, etc. Trying to board in the submarine when it is not shut off might lead to unexpected behaviors (boat going through the hull, player stuck in float animation at the rear of the submarine, trapdoor to the interior being slightly hidden in the hull, etc).

In order to keep this insertion vector as playable as possible, fast-travel is available, allowing a submarine to be instantly teleported to its destination, selected by the player on his map. However, for the sake of realism, the submarine cannot be fast-traveled on the surface, it will be moved 20m underwater. That's why it is not possible to teleport the submarine in shallow waters (<30m depth). However once the fast-travel is complete, manual driving of the submarine in shallow waters and in surface is perfectly fine.

Mind the tortoise !