### PR TITLE
fix: update pipeline actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
           target: ./
           
       - name: Upload pbo files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: addons
           path: ./*.pbo
 
       - name: Create Github release
-        uses: arwynfr/actions-conventional-versioning@v0
+        uses: arwynfr/actions-conventional-versioning@v1
         with:
-          pattern: $(Convert-Path *.pbo)
+          pattern: '*.pbo'


### PR DESCRIPTION
Uses an updated version of my conventional versioning GitHub Action, which solves a problem with GitHub CLI not expanding wildcards on Windows environments